### PR TITLE
The scoreLead field is better.

### DIFF
--- a/wgo_view/wgo/player.cgos.js
+++ b/wgo_view/wgo/player.cgos.js
@@ -171,7 +171,7 @@
           } else if (key == "winrate") {
             winrate = parseFloat(value);
             i++;
-          } else if (key == "scoreMean") {
+          } else if (key == "scoreLead") {
             score = parseFloat(value);
             i++;
           } else if (key == "pv") {


### PR DESCRIPTION
The KataGo GTP document says

* ```scoreMean``` - Same as scoreLead. "Mean" is a slight misnomer, but this field exists to preserve compatibility with existing tools.

The ```scoreLead``` is better and most tools use it.