### PR TITLE
Add CGOS toolbar

### DIFF
--- a/wgo_view/wgo/player.cgos.js
+++ b/wgo_view/wgo/player.cgos.js
@@ -2,7 +2,7 @@ import { WGo } from "./wgo";
 
 import { BasicPlayer } from "./basicplayer";
 import { Component } from "./basicplayer.component";
-import { Control, MenuItem } from "./basicplayer.control";
+import { Control, MenuItem, Button, Group } from "./basicplayer.control";
 
 // Utility
 
@@ -177,6 +177,13 @@ export const CgosAnalysisContext = function (player, board) {
 	this.board = board;
 	this.cgosMode = false;
 
+	this.showStats = true;
+	this.showOwnership = true;
+	this.showBlackWinrate = true;
+	this.showBlackScore = true;
+	this.showWhiteWinrate = true;
+	this.showWhiteScore = true;
+
 	this.ownershipLayer = new OwnershipLayer();
 	this.board.addLayer(this.ownershipLayer, 400);
 };
@@ -230,9 +237,56 @@ if (Control) {
 			}
 		}
 	});
+
+	const toggleHandler = function (prop) {
+		return function (player) {
+			player._cgos[prop] = !player._cgos[prop];
+			player.update(true);
+			return player._cgos[prop];
+		};
+	};
+
+	const initHandler = function (prop) {
+		return function (player) {
+			if (player._cgos[prop]) this.select();
+		};
+	};
+
+	const menuItems = [
+		["cgos-stats", "showStats"],
+		["cgos-ownership", "showOwnership"],
+		["cgos-bwinrate", "showBlackWinrate"],
+		["cgos-bscore", "showBlackScore"],
+		["cgos-wwinrate", "showWhiteWinrate"],
+		["cgos-wscore", "showWhiteScore"]
+	];
+
+	const widgets = [];
+	for (const [name, prop] of menuItems) {
+		widgets.push({
+			constructor: Button,
+			args: {
+				name: name,
+				togglable: true,
+				click: toggleHandler(prop),
+				init: initHandler(prop)
+			}
+		});
+	}
+
+	Control.widgets.push({
+		constructor: Group,
+		args: { name: "cgos", widgets: widgets }
+	});
 }
 
 WGo.i18n.en["cgos"] = "CGOS mode";
+WGo.i18n.en["cgos-stats"] = "Move stats";
+WGo.i18n.en["cgos-ownership"] = "Ownership";
+WGo.i18n.en["cgos-bwinrate"] = "Black winrate";
+WGo.i18n.en["cgos-bscore"] = "Black score";
+WGo.i18n.en["cgos-wwinrate"] = "White winrate";
+WGo.i18n.en["cgos-wscore"] = "White score";
 
 // CGOS variation overlay component.
 // Displays CGOS analysis information on the board.
@@ -261,9 +315,11 @@ const update_board = function (e) {
 		const tokens = JSON.parse(e.node.CC);
 		this._cgos.board._cgosColor = e.node.move.c;
 		this._cgos.infoList = [];
-		this._cgos.board._cgosOwnership = tokens.ownership;
+		this._cgos.board._cgosOwnership = this._cgos.showOwnership
+			? tokens.ownership
+			: null;
 
-		if (tokens.moves) {
+		if (this._cgos.showStats && tokens.moves) {
 			for (let j = 0; j < tokens.moves.length; j++) {
 				const info = tokens.moves[j];
 				let move = null;
@@ -640,10 +696,23 @@ const update = function (e) {
 	this.winrate.blackScore.setAttribute("points", this.blackScore.join(" "));
 	this.winrate.whiteWinrate.setAttribute("points", this.white.join(" "));
 	this.winrate.whiteScore.setAttribute("points", this.whiteScore.join(" "));
+
+	if (this.player && this.player._cgos) {
+		const f = this.player._cgos;
+		this.winrate.blackWinrate.style.display = f.showBlackWinrate
+			? ""
+			: "none";
+		this.winrate.blackScore.style.display = f.showBlackScore ? "" : "none";
+		this.winrate.whiteWinrate.style.display = f.showWhiteWinrate
+			? ""
+			: "none";
+		this.winrate.whiteScore.style.display = f.showWhiteScore ? "" : "none";
+	}
 };
 
 const EvaluationGraphBox = WGo.extendClass(Component, function (player) {
 	this.super(player);
+	this.player = player;
 	this.element.className = "wgo-analyzebox";
 
 	prepare_dom.call(this, player);

--- a/wgo_view/wgo/wgo.player.css
+++ b/wgo_view/wgo/wgo.player.css
@@ -537,15 +537,39 @@ button.wgo-button.wgo-selected:hover {
 }
 
 .wgo-button-menu::before  {
-	content: '\e81b';
-	font-size: 25px;
-	font-weight: normal;
-	padding-top: 5px;
+        content: '\e81b';
+        font-size: 25px;
+        font-weight: normal;
+        padding-top: 5px;
 }
 .wgo-button-about::before  {
-	content: '\e80f';
-	font-size: 30px;
-	font-weight: normal;
+        content: '\e80f';
+        font-size: 30px;
+        font-weight: normal;
+}
+.wgo-button-cgos-stats::before {
+        content: '\e801';
+        font-size: 25px;
+}
+.wgo-button-cgos-ownership::before {
+        content: '\e815';
+        font-size: 25px;
+}
+.wgo-button-cgos-bwinrate::before {
+        content: '\e813';
+        font-size: 25px;
+}
+.wgo-button-cgos-bscore::before {
+        content: '\e814';
+        font-size: 25px;
+}
+.wgo-button-cgos-wwinrate::before {
+        content: '\e800';
+        font-size: 25px;
+}
+.wgo-button-cgos-wscore::before {
+        content: '\e80f';
+        font-size: 25px;
 }
 
 /* move number widget */


### PR DESCRIPTION
## Summary
- switch CGOS feature toggles from menu items to a toolbar group
- map toolbar buttons to show stats, ownership and evaluation graph lines
- add CSS icons for CGOS toolbar buttons

## Testing
- `npm --prefix wgo_view run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix wgo_view run format`


------
https://chatgpt.com/codex/tasks/task_e_684ed5b41dfc83309c17bfeeccc45682